### PR TITLE
include LICENSE file in published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ include = [
     "**/*.c",
     "**/*.h",
     "Cargo.toml",
-    "README.md"
+    "README.md",
+    "LICENSE",
 ]
 
 [dependencies.libc]


### PR DESCRIPTION
(fixes the same issue as https://github.com/DoumanAsh/xxhash-rust/pull/13 did for xxhash-rust)